### PR TITLE
Make --separate-models and --separate-chains work again for CIF output.

### DIFF
--- a/src/cif.cc
+++ b/src/cif.cc
@@ -260,7 +260,7 @@ freesasa_cif_structure_array(std::FILE *input,
     std::vector<freesasa_structure *> ss;
 
     auto doc_idx_pair = generate_gemmi_doc(input);
-    auto doc = doc_idx_pair.first;
+    auto &doc = doc_idx_pair.first;
 
     gemmi::Structure gemmi_struct = gemmi::make_structure_from_block(doc.blocks[0]);
 
@@ -296,7 +296,7 @@ freesasa_cif_structure_array(std::FILE *input,
                 ss.push_back(std::move(structure));
 
                 freesasa_structure_set_model(ss.back(), i + 1);
-                // we don't set cif_ref here because output is not defined for --separate-chains
+                freesasa_structure_set_cif_ref(ss.back(), doc_idx_pair.second, NULL);
             }
         }
         if (n_chains == 0)

--- a/src/main.cc
+++ b/src/main.cc
@@ -713,9 +713,7 @@ parse_arg(int argc, char **argv, struct cli_state *state)
 
     if (state->output_format == FREESASA_CIF && state->cif != 1) abort_msg("CIF output can not be generated from .pdb input");
     if (state->output_format == FREESASA_PDB && state->cif == 1) abort_msg("PDB output can not be generated from .cif input.");
-    if (state->output_format == FREESASA_CIF && state->structure_options & FREESASA_SEPARATE_CHAINS)
-        abort_msg("Cannon output a cif file with --separate-chains");
-    if ((state->output_format == FREESASA_CIF || state->output_format == FREESASA_PDB) &&
+    if (state->output_format == FREESASA_PDB &&
         state->structure_options & FREESASA_SEPARATE_CHAINS &&
         state->structure_options & FREESASA_SEPARATE_MODELS)
         abort_msg("Cannot output a cif/pdb file with both --separate-chains and --separate-models set. Pick one.");

--- a/tests/test-cli.in
+++ b/tests/test-cli.in
@@ -236,10 +236,10 @@ assert_equal_total "$cli --join-models" "$datadir/2jo4.pdb" "$datadir/2jo4.cif -
 assert_equal_total "$cli --chain-groups AB+CD -S -n 10" "$datadir/2jo4.pdb" "$datadir/2jo4.cif --cif"
 assert_pass "$cli --cif --separate-models --format=cif $datadir/1ubq.cif > $dump"
 assert_pass "$cli --cif --format=cif $datadir/1ubq.cif > $dump"
-assert_fail "$cli --cif --format=cif --separate-chains $datadir/1ubq.cif > $dump"
+assert_pass "$cli --cif --format=cif --separate-chains $datadir/1ubq.cif > $dump"
+assert_pass "$cli --cif --format=cif --separate-chains --separate-models $datadir/1ubq.cif > $dump"
 assert_fail "$cli --cif --format=pdb $datadir/1ubq.cif > $dump"
 assert_fail "$cli --format=cif $datadir/1ubq.pdb > $dump"
-assert_fail "$cli --cif --format=cif --separate-chains --separate-models $datadir/1ubq.cif > $dump"
 
 echo
 echo "== Testing --separate-chains and --separate-models output are equal between cif and pdb"
@@ -327,6 +327,10 @@ assert_pass "$cli --rsa $datadir/1ubq.pdb > $dump"
 
 echo "== Verify idempotency of CIF format =="
 assert_equal_opt "$cli --cif --format=cif $datadir/1ubq.cif" "" " | $cli --cif --format=cif"
+assert_equal_opt "$cli --cif --format=cif --separate-chains $datadir/2jo4.cif" "" " | $cli --separate-chains --cif --format=cif"
+assert_equal_opt "$cli --cif --format=cif --separate-models $datadir/2jo4.cif" "" " | $cli --separate-models --cif --format=cif"
+assert_equal_opt "$cli --cif --format=cif --separate-models --separate-chains $datadir/2jo4.cif" "" \
+    " | $cli --separate-models --separate-chains --cif --format=cif"
 
 # XML // very basic testing, just to make sure XML is valid and that the right tags are present
 if [[ use_xml -eq 1 ]] ; then


### PR DESCRIPTION
I discovered that I had broken CIF output with `--separate-models` and `--separate-chains` with my last rewrite. This PR fixes that and adds a couple of tests. I also fixed the missing `return freesasa_fail...` in the main PR.

I also realized that the `--separate-chains` and `--separate-models` can be combined for this format, so I loosened that up. (Should have that setting printed under `freesasa_parameters` also?)

I think we're good to go when this is merged
